### PR TITLE
Removes the Pretty Filter from OOC

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -65,6 +65,8 @@
 
 /datum/config_entry/flag/allow_vote_mode	// allow votes to change mode
 
+/datum/config_entry/flag/pretty_ooc // Barony - Mark if OOC/Deadchat/LOOC should be run through the pretty filter or not
+
 /datum/config_entry/number/vote_delay	// minimum time between voting sessions (deciseconds, 10 minute default)
 	config_entry_value = 6000
 	min_val = 0

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -33,7 +33,9 @@
 	if(!msg)
 		return
 
-	msg = pretty_filter(msg) //yogs
+	
+	if(CONFIG_GET(flag/pretty_ooc))
+		msg = pretty_filter(msg)
 	msg = emoji_parse(msg)
 
 	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 6)), "say ")))

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -2,7 +2,7 @@
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if (!message)
 		return
-	if(CONFIG_GET(flag/pretty_ooc)
+	if(CONFIG_GET(flag/pretty_ooc))
 		message = pretty_filter(message)
 	
 	var/message_mode = get_message_mode(message)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -2,7 +2,9 @@
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if (!message)
 		return
-
+	if(CONFIG_GET(flag/pretty_ooc)
+		message = pretty_filter(message)
+	
 	var/message_mode = get_message_mode(message)
 	if(client && (message_mode == "admin" || message_mode == "deadmin"))
 		message = copytext(message, 3)

--- a/config/config.txt
+++ b/config/config.txt
@@ -162,7 +162,7 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 #ALLOW_VOTE_MODE
 
 ## Barony - Mark if OOC/Deadchat/LOOC should be run through the pretty filter or not
-PRETTY_OOC
+#PRETTY_OOC
 
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
 VOTE_DELAY 6000

--- a/config/config.txt
+++ b/config/config.txt
@@ -161,6 +161,9 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 ## allow players to initate a mode-change start
 #ALLOW_VOTE_MODE
 
+## Barony - Mark if OOC/Deadchat/LOOC should be run through the pretty filter or not
+PRETTY_OOC
+
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
 VOTE_DELAY 6000
 

--- a/yogstation/code/modules/client/verbs/looc.dm
+++ b/yogstation/code/modules/client/verbs/looc.dm
@@ -35,9 +35,11 @@
 	if(!msg)
 		return
 
-	msg = pretty_filter(msg)
+	if(CONFIG_GET(flag/pretty_ooc))
+		msg = pretty_filter(msg)
+	
 	//msg = emoji_parse(msg)
-
+	
 	if(!holder)
 		if(handle_spam_prevention(msg, MUTE_OOC))
 			return


### PR DESCRIPTION
### This seems like a bad idea but alright

@morrowwolf Asked me to do this, so I made the pretty filter something that could be disabled via the config for out-of-character communication. We can enable it later if this ends up being toxic.

