### PR TITLE
Implements loot-dropping for Goblins

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/goblin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goblin.dm
@@ -73,4 +73,7 @@
 	
 /mob/living/simple_animal/hostile/goblin/death(gibbed)
 	new /obj/effect/decal/cleanable/blood/splatter(get_turf(src), get_static_viruses())
+	if(prob(10)) // 10% chance of dropping loots
+		var/newthing = pick(/obj/item/melee/medieval/blade/shortsword,/obj/item/shields/medieval/wooden)
+		newthing = new newthing(loc)
 	return ..()


### PR DESCRIPTION
### Fuck I'm Tired

Tested this before doing the PR, seemed to work. 👍 

Right now it's just shortswords and wooden shields, and lootdropping is not yet a general proc or part of medieval mobs, but, whatever. Object orientation is for nerds.

Love ya :heart: