### PR TITLE
Fixes examining reagent containers

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -260,14 +260,13 @@
 		if(container_type & TRANSPARENT)
 			to_chat(user, "It contains:")
 			if(reagents.reagent_list.len)
-				if(user.can_see_reagents()) //Show each individual reagent
+				if(user.can_see_reagents()) //Show each individual reagent exactly (for ghosts and what have you)
 					for(var/datum/reagent/R in reagents.reagent_list)
 						to_chat(user, "[R.volume] units of [R.name]")
-				else //Otherwise, just show the total volume
-					var/total_volume = 0
+				else //Otherwise, just give a vaguer description
+					var/list/metrics = list("unces","lathers","shills","rounds") // random medieval-ish names of units
 					for(var/datum/reagent/R in reagents.reagent_list)
-						total_volume += R.volume
-					to_chat(user, "[total_volume] units of various reagents")
+						to_chat(user, "About [round(R.volume,0.5)] [pick(metrics)] of [R.name]")
 			else
 				to_chat(user, "Nothing.")
 		else if(container_type & AMOUNT_VISIBLE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -756,9 +756,13 @@
 /mob/proc/can_interact_with(atom/A)
 	return IsAdminGhost(src) || Adjacent(A)
 
-//Can the mob see reagents inside of containers?
+//Can the mob see the exact values for what's in the reagent container?
 /mob/proc/can_see_reagents()
-	return 1			//everyone can see into it for now because there's no other way to check and having an item for "scanning" would be dumb
+	if(stat == DEAD) //Ghosts and such can always see reagents
+		return 1
+	if(has_unlimited_silicon_privilege) //Silicons or whatever can automatically view reagents
+		return 1
+	return 0
 
 //Can the mob use Topic to interact with machines
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)


### PR DESCRIPTION
### It contains: 4.22284342942 units of Piss Water.
Makes it so that peasants can't just from a look know that there's exactly 4.2229 units of nutriment in their piss water. Also adds fake unit names, as per Parune's suggestion.

Fixes #152 

:heart: