### PR TITLE
Earn Your Beard + Generic framework for persistent character mechanics

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -355,3 +355,5 @@
 	config_entry_value = 0.1
 	integer = FALSE
 	min_val = 0
+
+/datum/config_entry/flag/earn_your_beard

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -37,15 +37,15 @@ BONUS
 			if(1, 2)
 				to_chat(H, "<span class='warning'>Your chin itches.</span>")
 				if(H.facial_hair_style == "Shaved")
-					H.facial_hair_style = "Jensen Beard"
+					H.change_facial_hair("Jensen Beard")
 					H.update_hair()
 			if(3, 4)
 				to_chat(H, "<span class='warning'>You feel tough.</span>")
 				if(!(H.facial_hair_style == "Dwarf Beard") && !(H.facial_hair_style == "Very Long Beard") && !(H.facial_hair_style == "Full Beard"))
-					H.facial_hair_style = "Full Beard"
+					H.change_facial_hair("Full Beard")
 					H.update_hair()
 			else
 				to_chat(H, "<span class='warning'>You feel manly!</span>")
 				if(!(H.facial_hair_style == "Dwarf Beard") && !(H.facial_hair_style == "Very Long Beard"))
-					H.facial_hair_style = pick("Dwarf Beard", "Very Long Beard")
+					H.change_facial_hair(pick("Dwarf Beard", "Very Long Beard"))
 					H.update_hair()

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -48,7 +48,7 @@ BONUS
 
 /datum/symptom/shedding/proc/Shed(mob/living/carbon/human/H, fullbald)
 	if(fullbald)
-		H.facial_hair_style = "Shaved"
+		H.change_facial_hair("Shaved")
 		H.hair_style = "Bald"
 	else
 		H.hair_style = "Balding Hair"

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -296,7 +296,7 @@
 	facial_hair_color = sanitize_hexcolor(getblock(structure, DNA_FACIAL_HAIR_COLOR_BLOCK))
 	skin_tone = GLOB.skin_tones[deconstruct_block(getblock(structure, DNA_SKIN_TONE_BLOCK), GLOB.skin_tones.len)]
 	eye_color = sanitize_hexcolor(getblock(structure, DNA_EYE_COLOR_BLOCK))
-	facial_hair_style = GLOB.facial_hair_styles_list[deconstruct_block(getblock(structure, DNA_FACIAL_HAIR_STYLE_BLOCK), GLOB.facial_hair_styles_list.len)]
+	change_facial_hair(GLOB.facial_hair_styles_list[deconstruct_block(getblock(structure, DNA_FACIAL_HAIR_STYLE_BLOCK), GLOB.facial_hair_styles_list.len)])
 	hair_style = GLOB.hair_styles_list[deconstruct_block(getblock(structure, DNA_HAIR_STYLE_BLOCK), GLOB.hair_styles_list.len)]
 	if(icon_update)
 		update_body()

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -115,7 +115,7 @@
 
 /obj/item/razor/proc/shave(mob/living/carbon/human/H, location = BODY_ZONE_PRECISE_MOUTH)
 	if(location == BODY_ZONE_PRECISE_MOUTH)
-		H.facial_hair_style = "Shaved"
+		H.change_facial_hair("Shaved")
 	else
 		H.hair_style = "Skinhead"
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -31,11 +31,20 @@
 
 		//handle facial hair (if necessary)
 		if(H.gender == MALE)
-			var/new_style = input(user, "Select a facial hair style", "Grooming")  as null|anything in GLOB.facial_hair_styles_list
-			if(userloc != H.loc)
-				return	//no tele-grooming
-			if(new_style)
-				H.facial_hair_style = new_style
+			while(H.client)
+				var/new_style = input(user, "Select a facial hair style", "Grooming")  as null|anything in GLOB.facial_hair_styles_list
+				var/datum/preferences/prefs
+				if(H.client && H.client.prefs)
+					prefs = H.client.prefs
+				if(userloc != H.loc)
+					return	//no tele-grooming
+				if(new_style)
+					var/datum/sprite_accessory/facial_hair/new_beard = GLOB.facial_hair_styles_list[new_style]
+					if(CONFIG_GET(flag/earn_your_beard) && new_beard && prefs && prefs.beard_level_enabled && new_beard.beard_level > prefs.beard_level)
+						to_chat(user, "You don't have enough hair to change to this beard.")
+						return
+					H.change_facial_hair(new_style)
+				break
 		else
 			H.facial_hair_style = "Shaved"
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -73,7 +73,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/datum/admins/proc/open_borgopanel,
 	/datum/admins/proc/restart, //yogs - moved from +server
 	/client/proc/admin_pick_random_player, //yogs
-	/client/proc/check_alts
+	/client/proc/check_alts,
+	/client/proc/freeze_streaks /* Freezes survival streak scores at their position for the round and does not automatically process them when the round is over */
 	)
 GLOBAL_PROTECT(admin_verbs_ban)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/DB_ban_panel, /client/proc/stickybanpanel))

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -17,7 +17,7 @@
 	H.underwear = random_underwear(H.gender)
 	H.skin_tone = random_skin_tone()
 	H.hair_style = random_hair_style(H.gender)
-	H.facial_hair_style = random_facial_hair_style(H.gender)
+	H.change_facial_hair(random_facial_hair_style(H.gender))
 	H.hair_color = random_short_color()
 	H.facial_hair_color = H.hair_color
 	H.eye_color = random_eye_color()
@@ -26,8 +26,8 @@
 	// Mutant randomizing, doesn't affect the mob appearance unless it's the specific mutant.
 	H.dna.features["mcolor"] = random_short_color()
 	H.dna.features["tail_lizard"] = pick(GLOB.tails_list_lizard)
-	H.dna.features["snout"] = pick(GLOB.snouts_list) 
-	H.dna.features["horns"] = pick(GLOB.horns_list) 
+	H.dna.features["snout"] = pick(GLOB.snouts_list)
+	H.dna.features["horns"] = pick(GLOB.horns_list)
 	H.dna.features["frills"] = pick(GLOB.frills_list)
 	H.dna.features["spines"] = pick(GLOB.spines_list)
 	H.dna.features["body_markings"] = pick(GLOB.body_markings_list)

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -514,7 +514,7 @@
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Dwarf Beards"))
 			for(var/mob/living/carbon/human/B in GLOB.carbon_list)
-				B.facial_hair_style = "Dward Beard"
+				B.facial_hair_style = "Dwarf Beard" //don't change to change_facial_hair, as it's an admin button, and we don't want admins to ruin earn your beard every time they use this
 				B.update_hair()
 			message_admins("[key_name_admin(usr)] activated dorf mode")
 

--- a/code/modules/admin/verbs/streak_freeze.dm
+++ b/code/modules/admin/verbs/streak_freeze.dm
@@ -1,0 +1,11 @@
+GLOBAL_VAR_INIT(survival_streak_frozen, FALSE)
+
+/client/proc/freeze_streaks()
+	set category = "Special Verbs"
+	set name = "Freeze Survival Streak"
+	set desc = "Survival streak features become frozen for this round. Players increasing or losing their streak will not be possible."
+
+	if(!GLOB.survival_streak_frozen && check_rights_for(src, R_FUN) && (alert(src, "This will freeze survival streak progress for all players this round, so that none of it actually gets saved. You will not be able to revert this. Are you sure?", "Freeze Survival Streak", "Yes", "No") == "Yes"))
+		GLOB.survival_streak_frozen = TRUE
+		log_admin("[key_name(src)] froze survival streaks for this round.")
+		message_admins("[key_name_admin(src)] froze survival streaks for this round.")

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -196,7 +196,7 @@
 	user.visible_message("<span class='suicide'>[user] is donning [src]! It looks like [user.p_theyre()] trying to be nice to girls.</span>")
 	user.say("M'lady.")
 	sleep(10)
-	H.facial_hair_style = "Neckbeard"
+	H.change_facial_hair("Neckbeard")
 	return(BRUTELOSS)
 
 /obj/item/clothing/head/sombrero

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -488,6 +488,9 @@
 		client.prefs.random_character()
 		client.prefs.real_name = client.prefs.pref_species.random_name(gender,1)
 	client.prefs.copy_to(H)
+	if(!(mind.assigned_role in GLOB.nonhuman_positions))
+		client.prefs.spawn_mob_ref = "[REF(H)]"
+		client.prefs.characters_spawned += client.prefs.default_slot
 	H.dna.update_dna_identity()
 	if(mind)
 		if(transfer_after)

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -518,11 +518,15 @@
 /datum/sprite_accessory/facial_hair
 	icon = 'icons/mob/human_face.dmi'
 	gender = MALE // barf (unless you're a dorf, dorfs dig chix w/ beards :P)
+	var/beard_level = 5
+	var/grow_beard = FALSE
 
 /datum/sprite_accessory/facial_hair/shaved
 	name = "Shaved"
 	icon_state = null
 	gender = NEUTER
+	beard_level = 0
+	grow_beard = TRUE
 
 /datum/sprite_accessory/facial_hair/watson
 	name = "Watson Mustache"
@@ -547,22 +551,29 @@
 /datum/sprite_accessory/facial_hair/neckbeard
 	name = "Neckbeard"
 	icon_state = "facial_neckbeard"
+	beard_level = 7
 
 /datum/sprite_accessory/facial_hair/fullbeard
 	name = "Full Beard"
 	icon_state = "facial_fullbeard"
+	grow_beard = TRUE
 
 /datum/sprite_accessory/facial_hair/longbeard
 	name = "Long Beard"
 	icon_state = "facial_longbeard"
+	grow_beard = TRUE
+	beard_level = 7
 
 /datum/sprite_accessory/facial_hair/vlongbeard
 	name = "Very Long Beard"
 	icon_state = "facial_wise"
+	grow_beard = TRUE
+	beard_level = 10
 
 /datum/sprite_accessory/facial_hair/elvis
 	name = "Elvis Sideburns"
 	icon_state = "facial_elvis"
+	beard_level = 5
 
 /datum/sprite_accessory/facial_hair/abe
 	name = "Abraham Lincoln Beard"
@@ -587,10 +598,14 @@
 /datum/sprite_accessory/facial_hair/dwarf
 	name = "Dwarf Beard"
 	icon_state = "facial_dwarf"
+	beard_level = 13
+	grow_beard = TRUE
 
 /datum/sprite_accessory/facial_hair/fiveoclock
 	name = "Five o Clock Shadow"
 	icon_state = "facial_fiveoclock"
+	grow_beard = TRUE
+	beard_level = 3
 
 /datum/sprite_accessory/facial_hair/fu
 	name = "Fu Manchu"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -21,7 +21,7 @@
 		set_species(dna.species.type)
 
 	guaranteed_butcher_results = dna.species.species_butcher_results
-		
+
 	//initialise organs
 	create_internal_organs() //most of it is done in set_species now, this is only for parent call
 	physiology = new()
@@ -191,7 +191,7 @@
 		if (org.bandaged)
 			dat += "<tr><td><i>[org.name]</i> wrapped with:</td><td><a href='byond://?src=\ref[src];unwrap=\ref[org.bandaged]'>[org.bandaged]</a></td></tr>"
 	// yogs end
-		
+
 	if(handcuffed)
 		dat += "<tr><td><B>Handcuffed:</B> <A href='?src=[REF(src)];item=[SLOT_HANDCUFFED]'>Remove</A></td></tr>"
 	if(legcuffed)
@@ -537,7 +537,7 @@
 			obscured |= SLOT_GLASSES
 		if(head.flags_inv & HIDEEARS)
 			obscured |= SLOT_EARS
-			
+
 	if(wear_neck)
 		if(wear_neck.flags_inv & HIDEMASK)
 			obscured |= SLOT_WEAR_MASK
@@ -630,9 +630,9 @@
 //Used for new human mobs created by cloning/goleming/podding
 /mob/living/carbon/human/proc/set_cloned_appearance()
 	if(gender == MALE)
-		facial_hair_style = "Full Beard"
+		change_facial_hair("Full Beard")
 	else
-		facial_hair_style = "Shaved"
+		change_facial_hair("Shaved")
 	hair_style = pick("Bedhead", "Bedhead 2", "Bedhead 3")
 	underwear = "Nude"
 	update_body()
@@ -913,6 +913,28 @@
 /mob/living/carbon/human/species/Initialize()
 	. = ..()
 	set_species(race)
+
+/mob/living/carbon/human/proc/change_facial_hair(var/new_facial_hair)
+	if(CONFIG_GET(flag/earn_your_beard))
+		for(var/ckey in GLOB.preferences_datums)
+			var/datum/preferences/P = GLOB.preferences_datums[ckey]
+			if(P.spawn_mob_ref == "[REF(src)]")
+				var/datum/sprite_accessory/facial_hair/beard = GLOB.facial_hair_styles_list[P.beard_level_beard]
+				var/datum/sprite_accessory/facial_hair/new_beard = GLOB.facial_hair_styles_list[new_facial_hair]
+				if(beard && new_beard)
+					var/character_slot = P.characters_spawned[P.characters_spawned.len]
+					P.load_consecutive_rounds(character_slot)
+					if(new_beard.beard_level > P.beard_level)
+						P.beard_level = 0
+						P.beard_level_beard = "Shaved"
+						to_chat(src, "<span class='notice'>As your facial hair changes, the surface of your face starts to feel extremely boring. You feel an inescapable urge to shave it off when you get back home.</span>")
+					else
+						if(new_beard.beard_level < beard.beard_level)
+							P.beard_level = new_beard.beard_level
+						P.beard_level_beard = new_facial_hair
+					P.save_consecutive_rounds(character_slot)
+				break
+	facial_hair_style = new_facial_hair
 
 /mob/living/carbon/human/species/abductor
 	race = /datum/species/abductor

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -619,7 +619,7 @@
 			if(prob(min(acidpwr*acid_volume/10, 90))) //Applies disfigurement
 				affecting.receive_damage(acidity, 2*acidity*damagemod) // yogs - Old Plant People
 				emote("scream")
-				facial_hair_style = "Shaved"
+				change_facial_hair("Shaved")
 				hair_style = "Bald"
 				update_hair()
 				add_trait(TRAIT_DISFIGURED, TRAIT_GENERIC)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1071,7 +1071,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/go_bald(mob/living/carbon/human/H)
 	if(QDELETED(H))	//may be called from a timer
 		return
-	H.facial_hair_style = "Shaved"
+	H.change_facial_hair("Shaved")
 	H.hair_style = "Bald"
 	H.update_hair()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -398,7 +398,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/N = M
 		N.hair_style = "Spiky"
-		N.facial_hair_style = "Shaved"
+		N.change_facial_hair("Shaved")
 		N.facial_hair_color = "000"
 		N.hair_color = "000"
 		if(!(HAIR in N.dna.species.species_traits)) //No hair? No problem!
@@ -1534,7 +1534,7 @@
 			var/datum/sprite_accessory/hair/picked_hair = pick(GLOB.hair_styles_list)
 			var/datum/sprite_accessory/facial_hair/picked_beard = pick(GLOB.facial_hair_styles_list)
 			H.hair_style = picked_hair
-			H.facial_hair_style = picked_beard
+			H.change_facial_hair(picked_beard)
 			H.update_hair()
 
 /datum/reagent/concentrated_barbers_aid
@@ -1550,7 +1550,7 @@
 		if(M && ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.hair_style = "Very Long Hair"
-			H.facial_hair_style = "Very Long Beard"
+			H.change_facial_hair("Very Long Beard")
 			H.update_hair()
 
 /datum/reagent/saltpetre

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -321,7 +321,7 @@
 		H.hair_color = hair_color
 		H.hair_style = hair_style
 		H.facial_hair_color = facial_hair_color
-		H.facial_hair_style = facial_hair_style
+		H.change_facial_hair(facial_hair_style)
 		H.lip_style = lip_style
 		H.lip_color = lip_color
 	if(real_name)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -537,3 +537,6 @@ DISABLE_HUMAN_MOOD
 
 ## A cap on how many monkeys may be created via monkey cubes
 MONKEYCAP 64
+
+## Earn Your Beard - Forces beard growth by surviving consecutive rounds. Comment it out to disable.
+EARN_YOUR_BEARD

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1113,6 +1113,7 @@
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\randomverbs.dm"
 #include "code\modules\admin\verbs\reestablish_db_connection.dm"
+#include "code\modules\admin\verbs\streak_freeze.dm"
 #include "code\modules\admin\verbs\spawnobjasmob.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"


### PR DESCRIPTION
Steals Earn Your Beard from a closed TG pull request, with some tweaks (like actually functioning). Also makes it forced and removed the weird animated effects from max level.

Basically, you can no longer choose a facial hair style. Instead, all males start shaved. If they survive a round, they get a beard point. Their beard is determined at the start of the round based on the number of beard points they have (Currently, the number of beards available to unlock is kind of lacking...). If they die, their points are reset to 0 and they'll start the next round shaved again.

This system can also be expanded for other persistent character things. Like age or something.